### PR TITLE
fix CRAN error messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ Depends:
 Encoding: UTF-8
 Imports: 
     Rcpp
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 LinkingTo: Rcpp

--- a/R/robxp.r
+++ b/R/robxp.r
@@ -10,9 +10,9 @@
 #' @export
 #' @return a classed object holding an external pointer to parsed robots.txt data
 #' @examples
-# imdb <- paste0(readLines(system.file("extdata", "imdb-robots.txt",
-#                package="spiderbar")), collapse="\n")
-# rt <- robxp(imdb)
+#' imdb <- paste0(readLines(system.file("extdata", "imdb-robots.txt",
+#'                package="spiderbar")), collapse="\n")
+#' rt <- robxp(imdb)
 robxp <- function(x) {
 
   if (inherits(x, "connection")) {

--- a/man/robxp.Rd
+++ b/man/robxp.Rd
@@ -19,3 +19,8 @@ a classed object holding an external pointer to parsed robots.txt data
 This function takes in a single element character vector and parses it into
 a `robxp` object.
 }
+\examples{
+imdb <- paste0(readLines(system.file("extdata", "imdb-robots.txt",
+               package="spiderbar")), collapse="\n")
+rt <- robxp(imdb)
+}

--- a/src/punycode.h
+++ b/src/punycode.h
@@ -6,7 +6,8 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
-
+#include <stdexcept> // added by dmi3kno 2021-05-21
+#include <limits> // added by dmi3kno 2021-05-21
 #include "utf8.h"
 
 namespace Url


### PR DESCRIPTION
I added the includes required to address the errors reported in the [CRAN log](https://cran.r-project.org/web/checks/check_results_spiderbar.html). The solution is inspired by similar issues in [other repositories](https://github.com/onnx/onnx-tensorrt/issues/474).
There was also a small roxygen syntax issue that needed a patch, so I fixed that as well.