### PR TITLE
fix the C++11 notes on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,6 @@ Description: The 'Robots Exclusion Protocol' <https://www.robotstxt.org/orig.htm
     a set of standards for allowing or excluding robot/spider crawling of different areas of
     site content. Tools are provided which wrap The 'rep-cpp' <https://github.com/seomoz/rep-cpp>
     C++ library for processing these 'robots.txt' files.
-SystemRequirements: C++11
 NeedsCompilation: yes
 URL: https://gitlab.com/hrbrmstr/spiderbar
 BugReports: https://gitlab.com/hrbrmstr/spiderbar/issues
@@ -23,5 +22,5 @@ Depends:
 Encoding: UTF-8
 Imports: 
     Rcpp
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 LinkingTo: Rcpp

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * custom print method now returns the object
 * fixed spelling
 * ensured there's a roxygen return for every function
+* fixed the CRAN note related to C++11 (removed the SystemRequirements from DESCRIPTION)
 
 0.2.0
 * Added crawl delay extraction

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,25 @@
+# Second submission
+
+* This is an update for an existing CRAN package.
+* This is a update release to patch the C++11 dependency note highlighted by Dr Ripley
+
+## Test environments
+- R-hub windows-x86_64-devel (r-devel)
+- R-hub ubuntu-gcc-release (r-release)
+- R-hub fedora-clang-devel (r-devel)
+
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+## revdepcheck results
+
+We checked 1 reverse dependencies (1 from CRAN), comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+
+# First submission
+
 ## Test environments
 * local R installation, R 4.0.1
 * ubuntu 16.04 (on travis-ci), R 4.0.1

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // rep_parse
 SEXP rep_parse(std::string content);
 RcppExport SEXP _spiderbar_rep_parse(SEXP contentSEXP) {


### PR DESCRIPTION
I removed SystemRequirements from DESCRIPTION, which is not required if you have `CXX_STD = CXX11` specification in makevars