### PR TITLE
Use .empty() over comparing .size() [implicitly] to 0

### DIFF
--- a/src/psl.cpp
+++ b/src/psl.cpp
@@ -101,7 +101,7 @@ namespace Url
         std::string tld(hostname.rbegin(), hostname.rend());
         std::transform(tld.begin(), tld.end(), tld.begin(), ::tolower);
 
-        while (tld.size())
+        while (!tld.empty())
         {
             auto it = levels.find(tld);
             if (it != levels.end())
@@ -145,7 +145,7 @@ namespace Url
         std::transform(result.begin(), result.end(), result.begin(), ::tolower);
 
         // Leading .'s indicate that the query had an empty segment
-        if (result.size() && result[0] == '.')
+        if (!result.empty() && result[0] == '.')
         {
             std::stringstream message;
             message << "Empty segment in " << result;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -492,7 +492,7 @@ namespace Url
         std::string copy;
         std::vector<size_t> segment_starts;
 
-        if (path_.size() >= 1 && path_[0] == '/')
+        if (!path_.empty() && path_[0] == '/')
         {
             copy.append(1, '/');
             segment_starts.push_back(0);
@@ -562,7 +562,7 @@ namespace Url
             directory = false;
         }
 
-        if (!directory && copy.size() >= 1)
+        if (!directory && !copy.empty())
         {
             copy.resize(copy.size() - 1);
         }


### PR DESCRIPTION
Identified by `clang-tidy`:

https://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html